### PR TITLE
/TEI/teiHeader/fileDesc/publicationStmt/authority

### DIFF
--- a/resources/xsl/citation.xsl
+++ b/resources/xsl/citation.xsl
@@ -100,7 +100,7 @@
             <xsl:sequence select="local:emit-responsible-persons(t:editor[@role='general'],'footnote',1)"/>
             <xsl:text>.</xsl:text>
         </xsl:for-each>
-        <xsl:text> Syriaca.org, 2016-.</xsl:text>
+        <xsl:text> Ceasarea City and Port Exploration Project, 2020-.</xsl:text>
         <!-- publication date statement -->
         <xsl:text> Entry published </xsl:text>
         <xsl:for-each select="../t:publicationStmt/t:date[1]">


### PR DESCRIPTION
@wsalesky in the How to Cite This Entry full Bibliography citation we currently have the publisher hard coded as "Syriaca.org" and the Date hard coded.

Instead, could we generate this from the TEI record in the following places:

/TEI/teiHeader/fileDesc/publicationStmt/authority

and /TEI/teiHeader/fileDesc/publicationStmt/date (but just take the year) ?

I have changed the hard coding here for now but perhaps this would be a better change to make to the whole app not just C-M.org?

thanks,
Dave